### PR TITLE
Addressing CodeQL violations and updating flagged dependencies

### DIFF
--- a/src/Azure.WebSites.DataProtection/Azure.WebSites.DataProtection.csproj
+++ b/src/Azure.WebSites.DataProtection/Azure.WebSites.DataProtection.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebSites.DataProtection</AssemblyName>
     <PackageId>Microsoft.Azure.WebSites.DataProtection</PackageId>
+    <LangVersion>latest</LangVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -16,9 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Azure.WebSites.DataProtection/JwtGenerator.cs
+++ b/src/Azure.WebSites.DataProtection/JwtGenerator.cs
@@ -37,7 +37,11 @@ namespace Microsoft.Azure.Web.DataProtection
 
         public static ClaimsPrincipal ValidateToken(string token, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
         {
-            validationParameters = validationParameters ?? GetDefaultValidationParameters();
+            if (validationParameters is null)
+            {
+                throw new ArgumentNullException(nameof(validationParameters));
+            }
+
             var handler = new JwtSecurityTokenHandler();
 
             return handler.ValidateToken(token, validationParameters, out validatedToken);
@@ -54,16 +58,6 @@ namespace Microsoft.Azure.Web.DataProtection
             {
                 return false;
             }
-        }
-
-        public static TokenValidationParameters GetDefaultValidationParameters()
-        {
-            return new TokenValidationParameters
-            {
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Util.GetDefaultKeyValue())),
-                ValidateAudience = false,
-                ValidateIssuer = false
-            };
         }
     }
 }

--- a/test/Azure.WebSites.DataProtection.UnitTests/Azure.WebSites.DataProtection.UnitTests.csproj
+++ b/test/Azure.WebSites.DataProtection.UnitTests/Azure.WebSites.DataProtection.UnitTests.csproj
@@ -7,12 +7,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.1.1" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Azure.WebSites.DataProtection.UnitTests/JwtGeneratorTests.cs
+++ b/test/Azure.WebSites.DataProtection.UnitTests/JwtGeneratorTests.cs
@@ -37,6 +37,8 @@ namespace Azure.WebSites.DataProtection.UnitTests
             {
                 var token = JwtGenerator.GenerateToken("testissuer", "testaudience");
 
+                // There are two separate CodeQL alerts for the same issue. The double comment on same line is intentional.
+                // CodeQL [SM04555] this handler does not verify AAD tokens. It verifies tokens issued by the platform. // CodeQL [SM04554] this handler does not verify AAD tokens. It verifies tokens issued by the platform.
                 var testParameters = new TokenValidationParameters()
                 {
                     IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestKeyValue)),


### PR DESCRIPTION
This change does introduce a breaking change by removing an API exposed by the `JwtGenerator`. This was a convenience API not used in the scenarios tracked by the extension, and with the change in place, consumers will simply have to pass the expected parameters to `ValidateToken` if needed.