### PR TITLE
Onboard NuGet restores to Central Feed Service

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,9 @@ jobs:
   - pwsh: dotnet --version
     displayName: "Echo dotnet version"
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
+
   - task: DotNetCoreCLI@2
     displayName: 'Build project'
     inputs:

--- a/eng/ci/templates/jobs/build-artifacts.yml
+++ b/eng/ci/templates/jobs/build-artifacts.yml
@@ -23,7 +23,10 @@ jobs:
   steps:
   - pwsh: dotnet --version
     displayName: "Echo dotnet version"
-  
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
+
   - task: DotNetCoreCLI@2
     displayName: 'Build project'
     inputs:


### PR DESCRIPTION
## Summary
- move NuGet source configuration to the repository root and route restores exclusively through the CFS `upstream-public` feed
- remove direct nuget.org and AzureFunctionsTempStaging source references
- authenticate NuGet before implicit restores in both legacy and templated Azure Pipelines build jobs

## Argument-boundary audit
- no CFS URL or repository-local feed/config path is inserted into a shell or process command by this change
- Azure Pipelines authentication uses the structured `NuGetAuthenticate@1` task, and the feed URL remains structured XML in `NuGet.config`
- verified restore with `NuGet.config` and the NuGet package cache located under Windows paths containing spaces, using a structured PowerShell argument array

## Validation
- clean-cache restore through CFS, including the Windows spaced-path case above
- `dotnet build Azure.Web.DataProtection.sln --no-restore -c Release`
- `dotnet test Azure.Web.DataProtection.sln --no-build --no-restore -c Release` (14 passed)