### PR TITLE
ci: stop scheduled builds for v0.x

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -12,7 +12,6 @@ schedules:
     branches:
       include:
       - main
-      - v0.x
     always: true
 
 # CI only, does not trigger on PRs.

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -14,7 +14,6 @@ schedules:
     branches:
       include:
       - main
-      - v0.x
     always: true
 
 pr:


### PR DESCRIPTION
## Summary

- stop nightly scheduled builds for the v0.x branch
- preserve normal CI and PR triggers for v0.x